### PR TITLE
Make SignatureHash() return 1 correctly; bug-for-bug

### DIFF
--- a/bitcoin/scripteval.py
+++ b/bitcoin/scripteval.py
@@ -21,7 +21,7 @@ from bitcoin.bignum import bn2vch, vch2bn
 
 def SignatureHash(script, txTo, inIdx, hashtype):
     if inIdx >= len(txTo.vin):
-        return (0, "inIdx %d out of range (%d)" % (inIdx, len(txTo.vin)))
+        return (1, "inIdx %d out of range (%d)" % (inIdx, len(txTo.vin)))
     txtmp = CTransaction()
     txtmp.copy(txTo)
 
@@ -39,7 +39,7 @@ def SignatureHash(script, txTo, inIdx, hashtype):
     elif (hashtype & 0x1f) == SIGHASH_SINGLE:
         outIdx = inIdx
         if outIdx >= len(txtmp.vout):
-            return (0, "outIdx %d out of range (%d)" % (outIdx, len(txtmp.vout)))
+            return (1, "outIdx %d out of range (%d)" % (outIdx, len(txtmp.vout)))
 
         tmp = txtmp.vout[outIdx]
         txtmp.vout = []
@@ -76,8 +76,6 @@ def CheckSig(sig, pubkey, script, txTo, inIdx, hashtype):
     sig = sig[:-1]
 
     tup = SignatureHash(script, txTo, inIdx, hashtype)
-    if tup[0] == 0:
-        return False
     return key.verify(ser_uint256(tup[0]), sig)
 
 def CheckMultiSig(opcode, script, stack, txTo, inIdx, hashtype):


### PR DESCRIPTION
If nOut >= vout.size() in the satoshi codebase SignatureHash() prints an
error to the debug log, and returns 1. Notably an actual error isn't
raised, and OP_CHECK(MULTI)SIG simply checks the signature against the
uint256 with the value one.

An example transaction where this occurs is
315ac7d4c26d69668129cc352851d9389b4a6868f1509c6c8b66bead11e2619f in
mainnet.
