### PR TITLE
Point users to new repo

### DIFF
--- a/README
+++ b/README
@@ -1,10 +1,5 @@
+Peter Todd has taken over maintainership of python-bitcoinlib. Please use the
+new repository at:
 
-This python library provides an easy interface to the bitcoin
-data structures and protocol.
+https://github.com/petertodd/python-bitcoinlib
 
-
-Unit tests
-----------
-
-python -m unittest discover
-python3 -m unittest discover


### PR DESCRIPTION
This should suffice for pointing users to the new repo, while not breaking links to anything within the repo itself unnecessarily. (as deleting the rest of the repo contents would do)
